### PR TITLE
Updated expired Discord link

### DIFF
--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -55,7 +55,7 @@ export const Footer = () => {
               <a href="https://t.me/joinchat/KByvmRe5wkR-8F_zz6AjpA" target="_blank" rel="noreferrer" className="m-0">
                 Telegram
               </a>
-              <a href="https://discord.gg/pRsr6rwG" target="_blank" rel="noreferrer" className="m-0">
+              <a href="https://discord.gg/84Abq4VbMQ" target="_blank" rel="noreferrer" className="m-0">
                 Discord
               </a>
               <a


### PR DESCRIPTION
## Description

The current Discord link is expired.  This replaces it with a new link with no expiration.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

Fixes #9 

Your ENS/address:
zg.frogbaseball.eth
