### PR TITLE
Spelling fix for 'Partnering with ecosystem heros' section: per-determined -> pre-determined

### DIFF
--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -280,7 +280,7 @@ const Home: NextPage<{
                 <br /> ecosystem heroes
               </h2>
               <p className="lg:w-4/5 m-0 mb-3">
-                Focused Cohort Streams bundle together a group of developer streams and focuses them on a per-determined
+                Focused Cohort Streams bundle together a group of developer streams and focuses them on a pre-determined
                 objective.
               </p>
               <p className="lg:w-4/5 m-0 mb-6">


### PR DESCRIPTION
Fixed typo under the "Partnering with ecosystem heros" section. Made per-determined say pre-determined
