### PR TITLE
fix: change links to se-2 challenges

### DIFF
--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -109,21 +109,21 @@ const Home: NextPage<{
               name="Build a DEX"
               src="/assets/chall-dex.png"
               description="💵 Build an exchange that swaps ETH to tokens and tokens to ETH."
-              link="https://github.com/scaffold-eth/scaffold-eth-challenges/tree/challenge-4-dex"
+              link="https://github.com/scaffold-eth/se-2-challenges/tree/challenge-4-dex"
             />
             <Card
               num={5}
               name="State Channels"
               src="/assets/chall-state.png"
               description="🐌 The Ethereum blockchain has great decentralization & security properties. These properties come at a price!"
-              link="https://github.com/scaffold-eth/scaffold-eth-challenges/tree/challenge-9-state-channels"
+              link="https://github.com/scaffold-eth/se-2-challenges/tree/challenge-5-state-channels"
             />
             <Card
               num={6}
-              name="Multi-Sig Wallet"
+              name="Multisig Wallet"
               src="/assets/chall-multisig.png"
               description="👩‍👩‍👧‍👧 Using a smart contract as a wallet we can secure assets by requiring multiple accounts to 'vote' on transactions."
-              link="https://github.com/scaffold-eth/scaffold-eth-challenges/tree/challenge-5-multisig"
+              link="https://github.com/scaffold-eth/se-2-challenges/tree/challenge-6-multisig"
             />
           </div>
         </div>


### PR DESCRIPTION
## Description

Changes challenges-links from `scaffold-eth-challenges` to `se-2-challenges`

Also changed "Multi-Sig" to "Multisig" like in speedrunethereum page

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)
