### PR TITLE
Fix bug on AddressInput

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -55,7 +55,7 @@ export const AddressInput = ({ value, name, placeholder, disabled, onChange }: A
       setEnteredEnsName(undefined);
       onChange(newValue);
     },
-    [onChange],
+    [onChange, value],
   );
 
   return (

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -50,12 +50,16 @@ export const AddressInput = ({ value, name, placeholder, disabled, onChange }: A
     onChange(ensAddress);
   }, [ensAddress, onChange, value]);
 
+  useEffect(() => {
+    setEnteredEnsName(undefined);
+  }, [value]);
+
   const handleChange = useCallback(
     (newValue: Address) => {
       setEnteredEnsName(undefined);
       onChange(newValue);
     },
-    [onChange, value],
+    [onChange],
   );
 
   return (


### PR DESCRIPTION
There is an issue with addressInput in some scenarios.

To reproduce the bug:
- Search for any ens address (e.g. atg.eth)
- Connect a wallet with a different address (e.g. buidlguidl.carletex.eth)
=> It will still show the old ens 

![71deff77-9d63-4466-8933-137fd5e38d7c](https://github.com/user-attachments/assets/76189126-d2c0-4173-9e46-ced75c9d1e5f)

The cause was we weren't resetting `enteredEnsName` on value change.

This seemed the best way to fix it, and didn't find any consequences.

After you'all review this, I'll create a PR on SE-2 too


