### PR TITLE
Change SE-2 link from github to SE-2 website

### DIFF
--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -129,7 +129,7 @@ const Home: NextPage<{
             <div className="text-center lg:text-left">
               <TrackedLink
                 id="Scaffold-ETH-2"
-                href="https://www.github.com/scaffold-eth/scaffold-eth-2"
+                href="https://scaffoldeth.io"
                 className="btn btn-accent btn-md lg:self-start px-8 hover:opacity-100"
               >
                 Start using SE-2


### PR DESCRIPTION
I think it's better to link the SE-2 website now.