### PR TITLE
Adjust batch table (removed github links, upcoming batch), added next starting to batch banner

### DIFF
--- a/packages/nextjs/pages/batches/index.tsx
+++ b/packages/nextjs/pages/batches/index.tsx
@@ -28,7 +28,7 @@ function getBatchNumber(batchName: string): number {
 interface PageProps {
   batchData: BatchData[];
   openBatchNumber: number | null;
-  nextBatchStartDate: number | null;
+  openBatchStartDate: number | null;
 }
 
 const formatDate = (timestamp: number): string => {
@@ -63,11 +63,11 @@ const BatchesHeader = () => {
   );
 };
 
-const Batches = ({ batchData, openBatchNumber, nextBatchStartDate }: PageProps) => {
+const Batches = ({ batchData, openBatchNumber, openBatchStartDate }: PageProps) => {
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
 
-  const filteredBatchData = batchData.filter(batch => batch.startDate <= Date.now());
+  const filteredBatchData = batchData.filter(batch => batch.status === "closed");
 
   // Calculate pagination
   const indexOfLastItem = currentPage * itemsPerPage;
@@ -180,7 +180,7 @@ const Batches = ({ batchData, openBatchNumber, nextBatchStartDate }: PageProps) 
                 </h3>
                 <p className="text-white pr-2">
                   Complete SpeedRunEthereum and join BuidlGuidl to be part of the next batch starting
-                  <strong>{nextBatchStartDate ? ` on ${formatDate(nextBatchStartDate)}` : "soon"}!</strong>
+                  <strong>{openBatchStartDate ? ` on ${formatDate(openBatchStartDate)}` : "soon"}!</strong>
                 </p>
               </div>
               <div className="flex justify-center lg:justify-end w-full lg:w-auto">
@@ -289,16 +289,16 @@ export const getStaticProps: GetStaticProps<PageProps> = async () => {
     // Find open batch number or calculate next batch number
     const openBatch = batchesData.find(batch => batch.status === "open");
     let openBatchNumber: number | null = null;
-    let nextBatchStartDate: number | null = null;
+    let openBatchStartDate: number | null = null;
 
     if (openBatch) {
       openBatchNumber = parseInt(openBatch.name);
-      nextBatchStartDate = openBatch.startDate;
+      openBatchStartDate = openBatch.startDate;
     } else {
       // Find the highest batch number and add 1
       const highestBatch = Math.max(...batchesData.map(batch => parseInt(batch.name)));
       openBatchNumber = highestBatch + 1;
-      nextBatchStartDate = null;
+      openBatchStartDate = null;
     }
 
     // Enrich batch data with additional fields
@@ -318,7 +318,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async () => {
       props: {
         batchData: sortedBatches,
         openBatchNumber: openBatchNumber,
-        nextBatchStartDate,
+        openBatchStartDate,
       },
       // 6 hours refresh
       revalidate: 21600,
@@ -329,7 +329,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async () => {
       props: {
         batchData: [],
         openBatchNumber: null,
-        nextBatchStartDate: null,
+        openBatchStartDate: null,
       },
       revalidate: 21600,
     };

--- a/packages/nextjs/pages/batches/index.tsx
+++ b/packages/nextjs/pages/batches/index.tsx
@@ -28,6 +28,7 @@ function getBatchNumber(batchName: string): number {
 interface PageProps {
   batchData: BatchData[];
   openBatchNumber: number | null;
+  nextBatchStartDate: number | null;
 }
 
 const formatDate = (timestamp: number): string => {
@@ -62,7 +63,7 @@ const BatchesHeader = () => {
   );
 };
 
-const Batches = ({ batchData, openBatchNumber }: PageProps) => {
+const Batches = ({ batchData, openBatchNumber, nextBatchStartDate }: PageProps) => {
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
 
@@ -178,7 +179,8 @@ const Batches = ({ batchData, openBatchNumber }: PageProps) => {
                   Batch #{openBatchNumber}
                 </h3>
                 <p className="text-white pr-2">
-                  Complete SpeedRunEthereum and join BuidlGuidl to participate in the next Batch!
+                  Complete SpeedRunEthereum and join BuidlGuidl to be part of the next batch starting
+                  <strong>{nextBatchStartDate ? ` on ${formatDate(nextBatchStartDate)}` : "soon"}!</strong>
                 </p>
               </div>
               <div className="flex justify-center lg:justify-end w-full lg:w-auto">
@@ -287,13 +289,16 @@ export const getStaticProps: GetStaticProps<PageProps> = async () => {
     // Find open batch number or calculate next batch number
     const openBatch = batchesData.find(batch => batch.status === "open");
     let openBatchNumber: number | null = null;
+    let nextBatchStartDate: number | null = null;
 
     if (openBatch) {
       openBatchNumber = parseInt(openBatch.name);
+      nextBatchStartDate = openBatch.startDate;
     } else {
       // Find the highest batch number and add 1
       const highestBatch = Math.max(...batchesData.map(batch => parseInt(batch.name)));
       openBatchNumber = highestBatch + 1;
+      nextBatchStartDate = null;
     }
 
     // Enrich batch data with additional fields
@@ -313,6 +318,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async () => {
       props: {
         batchData: sortedBatches,
         openBatchNumber: openBatchNumber,
+        nextBatchStartDate,
       },
       // 6 hours refresh
       revalidate: 21600,
@@ -323,6 +329,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async () => {
       props: {
         batchData: [],
         openBatchNumber: null,
+        nextBatchStartDate: null,
       },
       revalidate: 21600,
     };

--- a/packages/nextjs/pages/batches/index.tsx
+++ b/packages/nextjs/pages/batches/index.tsx
@@ -76,7 +76,7 @@ const Batches = ({ batchData, openBatchNumber, nextBatchStartDate }: PageProps) 
 
   const paginate = (pageNumber: number) => setCurrentPage(pageNumber);
 
-  const totalPages = Math.ceil(batchData.length / itemsPerPage);
+  const totalPages = Math.ceil(filteredBatchData.length / itemsPerPage);
 
   return (
     <>

--- a/packages/nextjs/pages/batches/index.tsx
+++ b/packages/nextjs/pages/batches/index.tsx
@@ -66,10 +66,12 @@ const Batches = ({ batchData, openBatchNumber }: PageProps) => {
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
 
+  const filteredBatchData = batchData.filter(batch => batch.startDate <= Date.now());
+
   // Calculate pagination
   const indexOfLastItem = currentPage * itemsPerPage;
   const indexOfFirstItem = indexOfLastItem - itemsPerPage;
-  const currentItems = batchData.slice(indexOfFirstItem, indexOfLastItem);
+  const currentItems = filteredBatchData.slice(indexOfFirstItem, indexOfLastItem);
 
   const paginate = (pageNumber: number) => setCurrentPage(pageNumber);
 
@@ -230,13 +232,6 @@ const Batches = ({ batchData, openBatchNumber }: PageProps) => {
                             Website
                           </TrackedLink>
                           <div className="flex items-center gap-1">
-                            <TrackedLink
-                              id={`${batch.name}-github`}
-                              href={batch.githubRepoLink || ""}
-                              className="btn btn-xs btn-ghost p-0 min-h-0 w-[24px] h-[24px] hover:opacity-80 flex items-center justify-center"
-                            >
-                              <Image src="/assets/github-logo.png" alt="GitHub" width={24} height={24} />
-                            </TrackedLink>
                             {batch.nftContractAddress && batch.graduates > 0 && (
                               <TrackedLink
                                 id={`${batch.name}-opensea`}


### PR DESCRIPTION
## Description

New batch participants can easily access previous batch repositories and copy code from them. Even before the batch starts, they see what how the batch program looks like, which reduces the element of surprise. For this reason, I’d like to remove the GitHub links from the table. (I know the repositories aren’t too difficult to find otherwise, but it makes it less obvious). 

I also removed the upcoming batch from the table and integrated the start date into the banner above.

Let me know if these changes work for you!

<img width="1210" alt="Screenshot 2024-12-20 at 11 29 02" src="https://github.com/user-attachments/assets/5daef487-1f1e-48d2-aa38-ee2adbc690ea" />


