### PR TITLE
Fixed client card image

### DIFF
--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -378,7 +378,7 @@ const Home: NextPage<{
             />
             <LearnMoreCard
               name="📡 BuidlGuidl on X"
-              src="/assets/bg-client.png"
+              src="/assets/bg-client-card.png"
               description="Follow us on X for updates on Ethereum developer experience and onbaording!"
               link="https://x.com/buidlguidl"
             />


### PR DESCRIPTION
Quick fix of a broken image name of the last PR, in the client's card at the Learn more section.