### PR TITLE
Change link to sre

### DIFF
--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -20,7 +20,7 @@ export const Footer = () => {
           <div className="grid grid-cols-12 gap-y-6 gap-x-0 xs:gap-x-6">
             <div className="flex flex-col col-span-12 sm:col-span-4 text-white space-y-2 font-thin">
               <p className="m-0 text-info font-normal">BuidlGuidl</p>
-              <a href="https://app.buidlguidl.com/builds" target="_blank" rel="noreferrer" className="m-0">
+              <a href="https://speedrunethereum.com/builds" target="_blank" rel="noreferrer" className="m-0">
                 Builds
               </a>
               <a href="https://github.com/scaffold-eth/scaffold-eth-2" target="_blank" rel="noreferrer" className="m-0">

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import Image from "next/image";
 import Link from "next/link";
-import TrackedLink from "~~/components/TrackedLink";
 
 /**
  * Site header
@@ -15,15 +14,6 @@ export const Header = () => {
             <Image alt="SE2 logo" className="cursor-pointer" fill src="/logo.svg" />
           </div>
         </Link>
-      </div>
-      <div className="navbar-end flex-grow mr-4 space-x-6 z-10">
-        <TrackedLink
-          id="buidlguidl:app"
-          href="https://speedrunethereum.com"
-          className="btn btn-neutral hover:bg-info hover:border-info text-accent-content btn-xs md:btn-sm px-4 font-light hover:opacity-100"
-        >
-          Go to App
-        </TrackedLink>
       </div>
     </div>
   );

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -19,7 +19,7 @@ export const Header = () => {
       <div className="navbar-end flex-grow mr-4 space-x-6 z-10">
         <TrackedLink
           id="buidlguidl:app"
-          href="https://app.buidlguidl.com"
+          href="https://speedrunethereum.com"
           className="btn btn-neutral hover:bg-info hover:border-info text-accent-content btn-xs md:btn-sm px-4 font-light hover:opacity-100"
         >
           Go to App

--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -15,27 +15,27 @@ const nextConfig = {
     return [
       {
         source: "/builders",
-        destination: "https://app.buidlguidl.com/builders",
+        destination: "https://speedrunethereum.com/builders",
         permanent: true,
       },
       {
         source: "/builders/:address",
-        destination: "https://app.buidlguidl.com/builders/:address",
+        destination: "https://speedrunethereum.com/builders:address",
         permanent: true,
       },
       {
         source: "/build/:buildId",
-        destination: "https://app.buidlguidl.com/build/:buildId",
+        destination: "https://speedrunethereum.com/build/:buildId",
         permanent: true,
       },
       {
         source: "/builds",
-        destination: "https://app.buidlguidl.com/builds",
+        destination: "https://speedrunethereum.com/builds",
         permanent: true,
       },
       {
         source: "/activity",
-        destination: "https://app.buidlguidl.com/activity",
+        destination: "https://speedrunethereum.com/activity",
         permanent: true,
       },
     ];

--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -35,7 +35,7 @@ const nextConfig = {
       },
       {
         source: "/activity",
-        destination: "https://speedrunethereum.com/activity",
+        destination: "https://speedrunethereum.com/admin/activity",
         permanent: true,
       },
     ];

--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -25,7 +25,7 @@ const nextConfig = {
       },
       {
         source: "/build/:buildId",
-        destination: "https://speedrunethereum.com/build/:buildId",
+        destination: "https://app.buidlguidl.com/build/:buildId",
         permanent: true,
       },
       {

--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -20,7 +20,7 @@ const nextConfig = {
       },
       {
         source: "/builders/:address",
-        destination: "https://speedrunethereum.com/builders:address",
+        destination: "https://speedrunethereum.com/builders/:address",
         permanent: true,
       },
       {

--- a/packages/nextjs/pages/batches/index.tsx
+++ b/packages/nextjs/pages/batches/index.tsx
@@ -48,15 +48,6 @@ const BatchesHeader = () => {
           </div>
         </Link>
       </div>
-      <div className="navbar-end flex-grow mr-4 space-x-6 z-10">
-        <TrackedLink
-          id="buidlguidl:app"
-          href="https://speedrunethereum.com"
-          className="btn btn-primary bg-info hover:border-info text-[#182232] btn-xs md:btn-sm md:px-5 hover:opacity-100"
-        >
-          Go to app
-        </TrackedLink>
-      </div>
     </div>
   );
 };

--- a/packages/nextjs/pages/batches/index.tsx
+++ b/packages/nextjs/pages/batches/index.tsx
@@ -51,7 +51,7 @@ const BatchesHeader = () => {
       <div className="navbar-end flex-grow mr-4 space-x-6 z-10">
         <TrackedLink
           id="buidlguidl:app"
-          href="https://app.buidlguidl.com"
+          href="https://speedrunethereum.com"
           className="btn btn-primary bg-info hover:border-info text-[#182232] btn-xs md:btn-sm md:px-5 hover:opacity-100"
         >
           Go to app

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -237,7 +237,7 @@ const Home: NextPage<{
               link="https://address.vision/"
             />
           </div>
-          <TrackedLink id="buidlguidl:projects" href="https://app.buidlguidl.com/builds" className="link mt-8">
+          <TrackedLink id="buidlguidl:projects" href="https://speedrunethereum.com/builds" className="link mt-8">
             See all projects
           </TrackedLink>
         </div>


### PR DESCRIPTION
Hey!

I’ve updated the links to point to SRE.
Now, whenever someone clicks, they’ll be redirected to Speedrun instead of app.buidlguild.com.

<img width="190" height="77" alt="Screenshot 2025-08-21 at 13 21 03" src="https://github.com/user-attachments/assets/fc11c680-81e7-4ab0-8e47-cc3f28b5fb35" />

For the /activity redirect I wasn’t sure whether we should keep it or remove it, what do you think?

Thanks!