### PR TITLE
Standardize naming to 'Speedrun Ethereum'

### DIFF
--- a/packages/nextjs/components/batches/BatchCta.tsx
+++ b/packages/nextjs/components/batches/BatchCta.tsx
@@ -15,7 +15,7 @@ export const BatchCta = ({ openBatchNumber, openBatchStartDate }: BatchCtaProps)
             Batch #{openBatchNumber}
           </h3>
           <p className="text-white">
-            Complete SpeedRunEthereum and join the next BuidlGuidl Batch starting
+            Complete Speedrun Ethereum and join the next BuidlGuidl Batch starting
             <strong>{openBatchStartDate ? ` on ${formatDate(openBatchStartDate)}` : " soon"}!</strong>
           </p>
         </div>
@@ -25,7 +25,7 @@ export const BatchCta = ({ openBatchNumber, openBatchStartDate }: BatchCtaProps)
             href="https://speedrunethereum.com/"
             className="btn btn-sm bg-white text-primary hover:bg-gray-100 transition-colors duration-300 inline-flex items-center justify-center whitespace-nowrap"
           >
-            Go SpeedRunEthereum
+            Go Speedrun Ethereum
           </TrackedLink>
         </div>
       </div>

--- a/packages/nextjs/pages/devcon/index.tsx
+++ b/packages/nextjs/pages/devcon/index.tsx
@@ -195,7 +195,7 @@ const Devon2024 = () => {
                   target="_blank"
                   rel="noreferrer"
                 >
-                  Speed Run Ethereum
+                  Speedrun Ethereum
                 </a>{" "}
                 to learn about smart contracts, Ethereum development, and join the BuidlGuidl.
               </p>


### PR DESCRIPTION
Replace inconsistent variations (SpeedRunEthereum, SpeedRun Ethereum, Speed Run Ethereum) with the standardized form 'Speedrun Ethereum'.

Preserved:
- speedrunethereum.com domain
- Repository URLs
- Lowercase references in links

## Description

_Concise description of proposed changes, We recommend using screenshots and videos for better description_

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
