### PR TITLE
Pause Banner to Batch Page

### DIFF
--- a/packages/nextjs/components/batches/BatchCta.tsx
+++ b/packages/nextjs/components/batches/BatchCta.tsx
@@ -4,9 +4,38 @@ import TrackedLink from "~~/components/TrackedLink";
 interface BatchCtaProps {
   openBatchNumber: number | null;
   openBatchStartDate: string | null;
+  isPaused?: boolean;
 }
 
-export const BatchCta = ({ openBatchNumber, openBatchStartDate }: BatchCtaProps) => {
+export const BatchCta = ({ openBatchNumber, openBatchStartDate, isPaused = false }: BatchCtaProps) => {
+  // Show paused state when batches are paused
+  if (isPaused) {
+    return (
+      <div className="mt-16 mb-16 card bg-[#5f5fd3] px-6 lg:pl-6 py-8 max-w-full xs:max-w-[90%] md:max-w-[75%] xl:max-w-[60%] mx-auto">
+        <div className="card-body py-0 px-0 lg:py-0 lg:px-10 flex flex-col lg:flex-row items-center justify-between gap-6">
+          <div className="max-w-full lg:max-w-[65%] text-center lg:text-left">
+            <h3 className="card-title text-2xl text-white mb-3 justify-center lg:justify-start">
+              🚂 Batches Taking a Pit Stop
+            </h3>
+            <p className="text-white/90">
+              We&apos;re preparing the next adventure! In the meantime, start your journey with Speedrun Ethereum and be
+              ready when we return.
+            </p>
+          </div>
+          <div className="flex justify-center lg:justify-end w-full lg:w-auto">
+            <TrackedLink
+              id="apply-next-batch"
+              href="https://speedrunethereum.com/"
+              className="btn btn-sm bg-white text-[#5f5fd3] hover:bg-gray-100 transition-colors duration-300 inline-flex items-center justify-center whitespace-nowrap"
+            >
+              Go Speedrun Ethereum
+            </TrackedLink>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="mt-16 mb-16 card bg-gradient-to-r from-primary to-secondary px-6 lg:pl-6 py-8 max-w-full xs:max-w-[90%] md:max-w-[75%] xl:max-w-[60%] mx-auto">
       <div className="card-body py-0 px-0 lg:py-0 lg:px-10 flex flex-col lg:flex-row items-center justify-between gap-6">

--- a/packages/nextjs/pages/batches/index.tsx
+++ b/packages/nextjs/pages/batches/index.tsx
@@ -9,6 +9,9 @@ import { Footer } from "~~/components/Footer";
 import { MetaHeader } from "~~/components/MetaHeader";
 import TrackedLink from "~~/components/TrackedLink";
 
+// Toggle this to true when batches are paused
+const BATCHES_PAUSED = true;
+
 interface BatchData {
   id: number;
   name: string;
@@ -55,6 +58,7 @@ const BatchesHeader = () => {
 const Batches = ({ batchData, openBatchNumber, openBatchStartDate }: PageProps) => {
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
+  const isPaused = BATCHES_PAUSED;
 
   const filteredBatchData = batchData.filter(batch => batch.status === "closed");
 
@@ -73,6 +77,14 @@ const Batches = ({ batchData, openBatchNumber, openBatchStartDate }: PageProps) 
         title="BuidlGuidl Batches | Level Up Your Web3 Skills"
         description="Explore BuidlGuidl Batches to enhance your skills as a web3 developer. Join our program and collaborate with other Ethereum builders."
       />
+      {/* Paused Banner */}
+      {isPaused && (
+        <div className="bg-[#5f5fd3] text-white text-center py-3 px-4">
+          <p className="text-sm md:text-base font-medium">
+            🚂 <strong>Batches are taking a pit stop!</strong> We&apos;re preparing the next adventure, stay tuned!
+          </p>
+        </div>
+      )}
       {/* Hero section with custom header */}
       <div className="relative flex flex-col items-center pb-48">
         <div className="absolute inset-0 bg-gradient-to-b from-[#EAFFA9] via-[#f3ffca] to-[#EDEFFF]"></div>
@@ -139,7 +151,7 @@ const Batches = ({ batchData, openBatchNumber, openBatchStartDate }: PageProps) 
           </div>
 
           {/* Next Batch CTA */}
-          <BatchCta openBatchNumber={openBatchNumber} openBatchStartDate={openBatchStartDate} />
+          <BatchCta openBatchNumber={openBatchNumber} openBatchStartDate={openBatchStartDate} isPaused={isPaused} />
         </div>
       </div>
 
@@ -261,7 +273,7 @@ const Batches = ({ batchData, openBatchNumber, openBatchStartDate }: PageProps) 
       <div className="bg-[#EDEFFF] pt-16 lg:pt-8 pb-16">
         <div className="container max-w-[90%] lg:max-w-6xl mx-auto px-4 lg:px-12">
           {/* Next Batch CTA */}
-          <BatchCta openBatchNumber={openBatchNumber} openBatchStartDate={openBatchStartDate} />
+          <BatchCta openBatchNumber={openBatchNumber} openBatchStartDate={openBatchStartDate} isPaused={isPaused} />
 
           <div className="flex justify-center items-center mb-8">
             <Image src={"/assets/bg-batches-winners.svg"} alt={"Winners"} width={50} height={50} className="mr-3" />


### PR DESCRIPTION
Hi Pablo,

Added a BATCHES_PAUSED toggle flag and paused state UI to the batches page. When enabled, displays a top banner and updates the CTA cards to inform visitors that batches are temporarily paused.

Lets merge it on the end of the week. 

Let me know what you think! 

<img width="1381" height="812" alt="Screenshot 2026-01-05 at 17 05 51" src="https://github.com/user-attachments/assets/cf90cfc6-0dda-4ab4-b15f-322e6a4446a9" />

<img width="1251" height="446" alt="Screenshot 2026-01-05 at 17 06 02" src="https://github.com/user-attachments/assets/df1aa2dd-1f5a-4943-b06e-36abc0342919" />
