### PR TITLE
Add blog post list to llms.txt

### DIFF
--- a/packages/nextjs/public/llms.txt
+++ b/packages/nextjs/public/llms.txt
@@ -18,3 +18,9 @@
 - [Projects](https://buidlguidl.com/projects): open source tools and apps we build and maintain
 - [Blog](https://buidlguidl.com/blog): writing on tooling, education, and research
 - [Batches](https://buidlguidl.com/batches): a program to level up as an open source dApp developer
+
+## Blog posts
+- [Evaluating agent skills: testing whether they are actually useful](https://buidlguidl.com/blog/evaluating-agent-skills)
+- [Building an AI Agent From Scratch](https://buidlguidl.com/blog/building-ai-agent-from-scratch)
+- [RAG From the Ground Up](https://buidlguidl.com/blog/rag-from-the-ground-up)
+- [Shifting to an AI-Native Ethereum Developer Stack](https://buidlguidl.com/blog/ai-native-ethereum-stack)


### PR DESCRIPTION
Small follow-up to #82.

When we dropped `llms-full.txt` we also lost the list of blog posts, which was the one useful thing that file had that `llms.txt` didn't. Adding it back as a `## Blog posts` section.

Kept it static for now. At 4 posts a build script felt like more machinery than it's worth, and a missing post makes the list incomplete rather than wrong. Happy to generate it from `content/blog/*.md` later if the blog picks up a regular cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)