### PR TITLE
Add 2025 recap page

### DIFF
--- a/packages/nextjs/components/2025/RecapSection.tsx
+++ b/packages/nextjs/components/2025/RecapSection.tsx
@@ -1,0 +1,41 @@
+import { ReactNode } from "react";
+import { StatCard } from "./StatCard";
+
+export interface RecapStat {
+  value: string;
+  label: string;
+  growth?: string;
+}
+
+interface RecapSectionProps {
+  id: string;
+  track: string;
+  title: string;
+  intro: ReactNode;
+  stats?: RecapStat[];
+  children: ReactNode;
+}
+
+// White card section: track label + title + intro + stats + content, stacked vertically
+export const RecapSection = ({ id, track, title, intro, stats, children }: RecapSectionProps) => (
+  <section id={id} className="bg-white rounded-2xl shadow-md px-5 sm:px-10 py-8 sm:py-10 scroll-mt-8">
+    <div className="flex items-center gap-4 mb-5">
+      <span className="font-mono text-[10px] text-base-content/40 uppercase tracking-[0.2em]">{track}</span>
+      <span className="flex-1 max-w-[12rem] h-px bg-base-content/10" />
+    </div>
+
+    <h2 className="text-2xl sm:text-3xl mt-0 mb-4">{title}</h2>
+
+    <p className="text-base-content/70 leading-relaxed mt-0 mb-8">{intro}</p>
+
+    {stats && stats.length > 0 && (
+      <div className={`grid grid-cols-1 gap-4 mb-8 ${stats.length === 3 ? "sm:grid-cols-3" : "sm:grid-cols-2"}`}>
+        {stats.map(stat => (
+          <StatCard key={stat.value + stat.label} {...stat} />
+        ))}
+      </div>
+    )}
+
+    {children}
+  </section>
+);

--- a/packages/nextjs/components/2025/SectionNav.tsx
+++ b/packages/nextjs/components/2025/SectionNav.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from "react";
+import { RECAP_SECTIONS } from "./sections";
+
+const SECTIONS = RECAP_SECTIONS.map(({ id, title, navTitle }) => ({ id, title: navTitle ?? title }));
+
+// Sticky side navigation for the 2025 recap, styled like the blog TOC
+export const SectionNav = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeId, setActiveId] = useState<string>("");
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    observerRef.current = new IntersectionObserver(
+      entries => {
+        const visible = entries.filter(e => e.isIntersecting);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: "-20% 0px -60% 0px", threshold: 0 },
+    );
+
+    SECTIONS.forEach(section => {
+      const el = document.getElementById(section.id);
+      if (el) observerRef.current?.observe(el);
+    });
+
+    return () => observerRef.current?.disconnect();
+  }, []);
+
+  return (
+    <>
+      {/* Mobile nav */}
+      <div className="xl:hidden px-2">
+        <button
+          type="button"
+          onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          className="flex items-center gap-2.5 text-sm font-mono text-base-content/50 hover:text-base-content/80 transition-colors"
+        >
+          <svg
+            className={`w-3 h-3 transition-transform duration-200 ${isOpen ? "rotate-90" : ""}`}
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
+            <path
+              fillRule="evenodd"
+              d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+              clipRule="evenodd"
+            />
+          </svg>
+          <span className="uppercase tracking-wider text-xs">Contents</span>
+        </button>
+        {isOpen && (
+          <nav className="mt-4 ml-1 border-l border-base-content/10 animate-fade-in">
+            <ul className="space-y-1.5 py-1 list-none pl-0 my-0">
+              {SECTIONS.map(section => (
+                <li key={section.id}>
+                  <a
+                    href={`#${section.id}`}
+                    onClick={() => setIsOpen(false)}
+                    className={`block text-sm py-0.5 pl-3 transition-colors ${
+                      activeId === section.id
+                        ? "text-primary border-l-2 border-primary -ml-px font-medium"
+                        : "text-base-content/60 hover:text-base-content"
+                    }`}
+                  >
+                    {section.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
+      </div>
+
+      {/* Desktop sticky nav */}
+      <aside className="hidden xl:block w-52 shrink-0">
+        <nav className="sticky top-8">
+          <p className="text-[10px] font-mono text-base-content/40 uppercase tracking-[0.2em] mb-4">On this page</p>
+          <ul className="space-y-0.5 border-l border-base-content/10 list-none pl-0 my-0">
+            {SECTIONS.map(section => (
+              <li key={section.id}>
+                <a
+                  href={`#${section.id}`}
+                  className={`block text-[12.5px] leading-snug py-1 pl-3 transition-all duration-200 ${
+                    activeId === section.id
+                      ? "text-primary border-l-2 border-primary -ml-px font-medium"
+                      : "text-base-content/50 hover:text-base-content/80"
+                  }`}
+                >
+                  {section.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+    </>
+  );
+};

--- a/packages/nextjs/components/2025/StatCard.tsx
+++ b/packages/nextjs/components/2025/StatCard.tsx
@@ -1,0 +1,13 @@
+interface StatCardProps {
+  value: string;
+  label: string;
+  growth?: string;
+}
+
+export const StatCard = ({ value, label, growth }: StatCardProps) => (
+  <div className="border border-base-content/10 rounded-xl px-4 py-5 flex flex-col items-center text-center">
+    <span className="text-2xl sm:text-3xl font-bold tracking-tight">{value}</span>
+    {growth && <span className="font-mono text-xs text-base-content/70 mt-1.5">{growth}</span>}
+    {label && <span className="font-mono text-xs text-base-content/50 mt-1">{label}</span>}
+  </div>
+);

--- a/packages/nextjs/components/2025/TaskList.tsx
+++ b/packages/nextjs/components/2025/TaskList.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from "react";
+
+// Task list styled for the dark terminal window
+export const TaskList = ({ tasks }: { tasks: ReactNode[] }) => (
+  <div className="grid gap-2">
+    {tasks.map((task, index) => (
+      <div key={index} className="flex items-start gap-3 text-white/70">
+        <span className="text-secondary text-xs mt-1">◆</span>
+        <span className="text-sm leading-relaxed">{task}</span>
+      </div>
+    ))}
+  </div>
+);

--- a/packages/nextjs/components/2025/TerminalWindow.tsx
+++ b/packages/nextjs/components/2025/TerminalWindow.tsx
@@ -1,0 +1,166 @@
+import { ReactNode, useState } from "react";
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
+
+export interface TerminalTab {
+  id: string;
+  title: string;
+  content: ReactNode;
+  links?: { url: string; label: string }[];
+}
+
+interface TerminalWindowProps {
+  tabs: TerminalTab[];
+}
+
+const TabLinks = ({ links }: { links?: { url: string; label: string }[] }) => {
+  if (!links || links.length === 0) return null;
+  return (
+    <div className="flex items-center gap-5 mt-6">
+      {links.map(link => (
+        <a
+          key={link.url}
+          href={link.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:text-white text-sm transition-colors"
+        >
+          → {link.label}
+        </a>
+      ))}
+    </div>
+  );
+};
+
+const CatPrompt = ({ title }: { title: string }) => (
+  <div className="flex items-center gap-2 font-mono text-sm text-secondary mb-4">
+    <span>$</span>
+    <span>cat {title.toLowerCase().replace(/\s+/g, "-")}.md</span>
+  </div>
+);
+
+// Desktop version with tabs
+const DesktopTerminal = ({
+  tabs,
+  activeTab,
+  setActiveTab,
+}: {
+  tabs: TerminalTab[];
+  activeTab: string;
+  setActiveTab: (id: string) => void;
+}) => {
+  const activeContent = tabs.find(t => t.id === activeTab);
+
+  return (
+    <div className="hidden md:block rounded-xl overflow-hidden bg-[#212638] shadow-md">
+      {/* Title bar */}
+      <div className="flex items-stretch bg-white/[0.06] border-b border-white/[0.08]">
+        {/* Window controls (decorative) */}
+        <div className="flex items-center gap-1.5 px-4 py-2.5 shrink-0">
+          <span className="w-2.5 h-2.5 rounded-full bg-red-500" />
+          <span className="w-2.5 h-2.5 rounded-full bg-yellow-500" />
+          <span className="w-2.5 h-2.5 rounded-full bg-green-500" />
+        </div>
+
+        {/* Tab headers: natural width, scroll sideways when they don't fit */}
+        <div role="tablist" className="flex items-stretch flex-1 overflow-x-auto [scrollbar-width:thin]">
+          {tabs.map(tab => (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`shrink-0 flex items-center px-4 font-mono text-xs whitespace-nowrap border-l border-white/[0.08] transition-colors duration-200 ${
+                activeTab === tab.id ? "bg-white/10 text-white font-medium" : "text-white/40 hover:text-white/70"
+              }`}
+            >
+              {tab.title}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Content area */}
+      <div className="p-6">
+        {activeContent && (
+          <div>
+            <CatPrompt title={activeContent.title} />
+            {activeContent.content}
+            <TabLinks links={activeContent.links} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// Mobile version with accordion inside a single terminal frame
+const MobileTerminal = ({
+  tabs,
+  expandedTab,
+  toggleTab,
+}: {
+  tabs: TerminalTab[];
+  expandedTab: string | null;
+  toggleTab: (id: string) => void;
+}) => (
+  <div className="md:hidden rounded-xl overflow-hidden bg-[#212638] shadow-md">
+    {/* Title bar with window controls */}
+    <div className="flex items-center gap-1.5 px-4 py-2.5 bg-white/[0.06] border-b border-white/[0.08]">
+      <span className="w-2.5 h-2.5 rounded-full bg-red-500" />
+      <span className="w-2.5 h-2.5 rounded-full bg-yellow-500" />
+      <span className="w-2.5 h-2.5 rounded-full bg-green-500" />
+    </div>
+
+    {/* Accordion items */}
+    <div>
+      {tabs.map((tab, index) => {
+        const isExpanded = expandedTab === tab.id;
+        const isLast = index === tabs.length - 1;
+        return (
+          <div key={tab.id} className={!isLast ? "border-b border-white/[0.08]" : ""}>
+            <button
+              type="button"
+              onClick={() => toggleTab(tab.id)}
+              aria-expanded={isExpanded}
+              className="w-full flex items-center justify-between px-4 py-3 hover:bg-white/5 transition-colors"
+            >
+              <span className="font-mono text-sm text-white font-medium">{tab.title}</span>
+              <ChevronDownIcon
+                className={`w-5 h-5 text-white/40 transition-transform duration-200 ${isExpanded ? "rotate-180" : ""}`}
+              />
+            </button>
+
+            <div
+              className={`overflow-hidden transition-all duration-300 ease-in-out ${
+                isExpanded ? "max-h-[1200px] opacity-100" : "max-h-0 opacity-0 invisible"
+              }`}
+            >
+              <div className="px-4 pb-4">
+                <CatPrompt title={tab.title} />
+                {tab.content}
+                <TabLinks links={tab.links} />
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  </div>
+);
+
+export const TerminalWindow = ({ tabs }: TerminalWindowProps) => {
+  const [activeTab, setActiveTab] = useState<string>(tabs[0]?.id);
+  const [expandedTab, setExpandedTab] = useState<string | null>(tabs[0]?.id);
+
+  const toggleTab = (id: string) => {
+    setExpandedTab(expandedTab === id ? null : id);
+  };
+
+  return (
+    <>
+      <DesktopTerminal tabs={tabs} activeTab={activeTab} setActiveTab={setActiveTab} />
+      <MobileTerminal tabs={tabs} expandedTab={expandedTab} toggleTab={toggleTab} />
+    </>
+  );
+};

--- a/packages/nextjs/components/2025/sections.tsx
+++ b/packages/nextjs/components/2025/sections.tsx
@@ -1,0 +1,545 @@
+import { ReactNode } from "react";
+import { RecapStat } from "./RecapSection";
+import { TaskList } from "./TaskList";
+import { TerminalTab } from "./TerminalWindow";
+
+export interface RecapSectionData {
+  id: string;
+  track: string;
+  title: string;
+  // Shorter label for the side navigation; falls back to title
+  navTitle?: string;
+  intro: ReactNode;
+  stats?: RecapStat[];
+  tabs: TerminalTab[];
+}
+
+// Link styled for the dark terminal content
+const DarkLink = ({ href, children }: { href: string; children: ReactNode }) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="text-primary underline hover:text-white transition-colors"
+  >
+    {children}
+  </a>
+);
+
+const TerminalLabel = ({ children }: { children: ReactNode }) => (
+  <p className="font-mono text-xs text-white uppercase tracking-widest mt-6 mb-3">{children}</p>
+);
+
+// Inline "number + label" stats row inside the terminal
+const InlineStats = ({ stats }: { stats: { value: string; label: string }[] }) => (
+  <div className="flex items-center gap-4 flex-wrap mb-6">
+    {stats.map((stat, index) => (
+      <div key={stat.label} className="flex items-center gap-4">
+        {index > 0 && <span className="text-white/20">│</span>}
+        <div className="flex items-center gap-2">
+          <span className={`text-xl font-bold ${index % 2 === 0 ? "text-secondary" : "text-primary"}`}>
+            {stat.value}
+          </span>
+          <span className="text-white/50 text-xs">{stat.label}</span>
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+// Small bordered card for projects / prototypes inside the terminal
+const ProjectCard = ({
+  title,
+  description,
+  linkUrl,
+  linkLabel,
+}: {
+  title: string;
+  description: string;
+  linkUrl?: string;
+  linkLabel?: string;
+}) => (
+  <div className="p-4 border border-white/10 rounded-lg">
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <span className="text-white text-sm font-medium">{title}</span>
+        <p className="text-white/70 text-xs mt-1 mb-0">{description}</p>
+      </div>
+      {linkUrl ? (
+        <a
+          href={linkUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-secondary hover:text-white text-xs whitespace-nowrap transition-colors"
+        >
+          {linkLabel || "View"} →
+        </a>
+      ) : (
+        <span className="text-secondary text-xs whitespace-nowrap">WIP</span>
+      )}
+    </div>
+  </div>
+);
+
+const SPEEDRUN: RecapSectionData = {
+  id: "speedrun",
+  track: "Education / Dev Onboarding Track",
+  title: "Speedrun Ethereum",
+  intro: (
+    <>
+      Our flagship educational product. In 2025, we doubled down by shipping targeted UX, SEO, and gamification
+      improvements: increasing reach, signups, and challenge submissions.
+    </>
+  ),
+  stats: [
+    { value: "92.4k", label: "Unique Visitors", growth: "+74% from 2024" },
+    { value: "5,700", label: "Unique Signups", growth: "+114% from 2024" },
+    { value: "5,900", label: "Challenge Submissions", growth: "+40% from 2024" },
+  ],
+  tabs: [
+    {
+      id: "tasks",
+      title: "Tasks & Achievements",
+      content: (
+        <TaskList
+          tasks={[
+            "Add a builder portfolio page and side quests",
+            "Migrate builds from BuidlGuidl v3 and categorize them",
+            "Create 23 Solidity guides and additional landing pages, driving a 100% increase in organic traffic",
+            "Support the launch of five new challenges (Thanks Elliott and Philip!)",
+            "Launch Google Ads campaigns and collaborate with Blockscout on referral traffic",
+            "Improve conversion tracking and traffic source attribution",
+            "Automate feedback collection from past Speedrunners to measure career impact and improve the platform",
+            "Upgrade SRE to Scaffold-ETH 2",
+            "Migrate challenges to extensions for easier maintenance with future Scaffold-ETH 2 upgrades",
+          ]}
+        />
+      ),
+      links: [
+        { url: "https://speedrunethereum.com/", label: "Website" },
+        { url: "https://github.com/BuidlGuidl/SpeedRunEthereum-v2", label: "Github" },
+      ],
+    },
+  ],
+};
+
+const SCAFFOLD_ETH: RecapSectionData = {
+  id: "scaffold-eth",
+  track: "Dev Tooling Track",
+  title: "Scaffold-ETH 2 Ecosystem",
+  navTitle: "Scaffold-ETH 2",
+  intro: (
+    <>
+      Our modular toolkit for bootstrapping full-stack Ethereum apps. In 2025, we simplified the core, extracted
+      reusable packages, expanded extensions to better support onboarding and ecosystem integrations, and made it
+      AI-ready.
+    </>
+  ),
+  stats: [
+    { value: "2,243+", label: "created in 2025", growth: "public repositories" },
+    { value: "78k", label: "during 2025", growth: "npm downloads" },
+  ],
+  tabs: [
+    {
+      id: "toolkit",
+      title: "Toolkit",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            The core open-source toolkit for rapidly prototyping and building decentralized applications on Ethereum.
+          </p>
+          <TaskList
+            tasks={[
+              "Enable Scaffold-ETH 2 deployments to IPFS",
+              "Scaffold-ETH 2 it's showcased in the Mastering Ethereum v2 book",
+              "Implement encrypted private key support",
+              "Migrate to Tailwind v4 and DaisyUI v5",
+              "Migrate to Next.js 15",
+              "Improve documentation AI compatibility using llm-full.txt files",
+              "Add custom Cursor rules to enhance DX and enable easier one-shot dApp generation",
+              "Migrate documentation to the Vocs framework for improved styling, AI compatibility (ask ChatGPT), and dynamic unfurling",
+            ]}
+          />
+        </>
+      ),
+      links: [{ url: "https://github.com/scaffold-eth/scaffold-eth-2", label: "Github" }],
+    },
+    {
+      id: "create-eth",
+      title: "create-eth CLI",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            CLI to bootstrap new Scaffold-ETH 2 projects with customizable extensions (starter kits)
+          </p>
+          <TaskList
+            tasks={[
+              "Improve documentation for extension creators, including an args file example",
+              "Normalize template arguments and enable a more extensible system for extension developers",
+              "Fix GitHub API rate limit errors",
+              "Expose user-selected variables to extension developers via global variables",
+              "Add core extensions, including Porto, x402, and EIP-5792",
+            ]}
+          />
+        </>
+      ),
+      links: [{ url: "https://github.com/scaffold-eth/create-eth", label: "Github" }],
+    },
+    {
+      id: "website",
+      title: "Website",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            The <DarkLink href="https://scaffoldeth.io/">scaffoldeth.io</DarkLink> homepage, showcasing ecosystem
+            projects and resources for builders.
+          </p>
+          <TaskList
+            tasks={[
+              <>
+                Build Scaffold-ETH 2 usage tracker and send over 5000 repos using SE-2 to{" "}
+                <DarkLink href="https://github.com/electric-capital/open-dev-data">
+                  electric-capital/open-dev-data
+                </DarkLink>
+              </>,
+              <>
+                Ship <DarkLink href="https://projects.scaffoldeth.io/">projects.scaffoldeth.io</DarkLink> with SE-2
+                usage stats, adding stats and direct link to SE-2 homepage
+              </>,
+              "Add 'Build an app on Ethereum in 8 minutes' video to homepage",
+            ]}
+          />
+        </>
+      ),
+      links: [{ url: "https://github.com/scaffold-eth/scaffoldeth.io", label: "Github" }],
+    },
+    {
+      id: "scaffold-ui",
+      title: "Scaffold-UI",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            Standalone packages of reusable React hooks and UI components extracted from Scaffold-ETH 2.
+          </p>
+          <TaskList
+            tasks={[
+              "Monorepo setup with docs + example setup + packages setup",
+              "3 npm packages available (components, hooks, debug-contracts)",
+            ]}
+          />
+        </>
+      ),
+      links: [{ url: "https://github.com/scaffold-eth/scaffold-ui", label: "Github" }],
+    },
+    {
+      id: "burner-connector",
+      title: "Burner Connector",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            Lightweight wagmi connector for ephemeral burner wallets, enabling instant onboarding without extensions.
+          </p>
+          <TaskList tasks={["Maintenance", "Add compatibility with EIP-5792"]} />
+        </>
+      ),
+      links: [{ url: "https://www.npmjs.com/package/burner-connector", label: "NPM package" }],
+    },
+  ],
+};
+
+const EDUCATIONAL: RecapSectionData = {
+  id: "educational",
+  track: "Education / Dev Onboarding Track",
+  title: "Educational Initiatives",
+  intro: (
+    <>
+      We ran security challenges through our second edition of the Capture The Flag platform and contributed to key
+      community events, including our Builder Bootcamp at Devconnect Buenos Aires and dev support in Bhutan.
+    </>
+  ),
+  stats: [
+    { value: "1,600+", label: "", growth: "Flags minted" },
+    { value: "20+", label: "", growth: "Workshops" },
+  ],
+  tabs: [
+    {
+      id: "ctf",
+      title: "Capture The Flag",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            Hands-on security learning platform that challenges developers to solve real-world Web3 vulnerabilities. In
+            2025, we launched the CTF as a live, always-on platform and expanded it with a second season.
+          </p>
+          <InlineStats
+            stats={[
+              { value: "4,400", label: "visitors" },
+              { value: "1,645", label: "flags minted" },
+            ]}
+          />
+          <TaskList
+            tasks={[
+              "Released Devcon CTF as a live platform for anyone to play at any moment",
+              "Created 12 new challenges for Devconnect Argentina",
+              "Added Season 2 (Buenos Aires) to our CTF platform",
+            ]}
+          />
+        </>
+      ),
+      links: [{ url: "https://ctf.buidlguidl.com/", label: "Website" }],
+    },
+    {
+      id: "workshops",
+      title: "Workshops",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            We played a key role at Devconnect Buenos Aires, planning and executing BuidlGuidl{"'"}s four-day Builder
+            Bootcamp.
+          </p>
+
+          <div className="mb-6 p-4 border border-white/10 rounded-lg">
+            <div className="flex items-center justify-between mb-2">
+              <span className="font-mono text-xs text-white uppercase tracking-widest">
+                Builder Bootcamp • Nov 18-21
+              </span>
+              <a
+                href="https://devconnect.buidlguidl.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-secondary hover:text-white text-xs transition-colors"
+              >
+                View schedule →
+              </a>
+            </div>
+            <InlineStats
+              stats={[
+                { value: "4", label: "days" },
+                { value: "19", label: "workshops" },
+              ]}
+            />
+          </div>
+
+          <TerminalLabel>BuidlGuidl Sessions at Devconnect</TerminalLabel>
+          <TaskList
+            tasks={["Unveiling Scaffold UI", "Leveraging AI to build on Ethereum", "Capture the Flag session"]}
+          />
+
+          <TerminalLabel>Other Events</TerminalLabel>
+          <TaskList
+            tasks={[
+              <>
+                <DarkLink href="https://x.com/AyaMiyagotchi/status/1977798777634459923">Dev support</DarkLink> in
+                Bhutan, to help their government anchor its national digital identity system on Ethereum
+              </>,
+              <>
+                <DarkLink href="https://x.com/ethereumph/status/1963214275515961700">
+                  Ethereum fundamentals workshop
+                </DarkLink>{" "}
+                for instructors at universities
+              </>,
+              <>
+                <DarkLink href="https://www.aigentsbcn.xyz/">aigentsbcn</DarkLink> event support
+              </>,
+            ]}
+          />
+        </>
+      ),
+    },
+  ],
+};
+
+const ECOSYSTEM: RecapSectionData = {
+  id: "ecosystem",
+  track: "Dapp Building Track",
+  title: "Ecosystem Collabs",
+  intro: (
+    <>
+      Partnering with key players to expand Ethereum{"'"}s reach. In 2025, we partnered with ENS, Arbitrum, Geode Labs,
+      and Ethereum.org building grant platforms, cohort programs, and developer resources that benefit the broader
+      ecosystem.
+    </>
+  ),
+  tabs: [
+    {
+      id: "ens",
+      title: "ENS Grants",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            ETH Grants platform implemented adhoc for ENS in 2024, we improved it with milestone-based USDC grants in
+            2025 and enhanced admin workflow.
+          </p>
+          <TaskList
+            tasks={[
+              "Launched the new milestone-based USDC grants features",
+              "Added milestones and enhanced admin workflow to ETH grants",
+            ]}
+          />
+          <TerminalLabel>2025 Stats</TerminalLabel>
+          <InlineStats
+            stats={[
+              { value: "4.1k", label: "visitors" },
+              { value: "42 of 241", label: "grants approved" },
+              { value: "$200k+", label: "granted" },
+            ]}
+          />
+        </>
+      ),
+      links: [{ url: "https://builder.ensgrants.xyz/", label: "Website" }],
+    },
+    {
+      id: "arbitrum",
+      title: "Arbitrum",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            Launched the Arbitrum Cohort to build dapps on Arbitrum. Currently developing two projects for the
+            ecosystem.
+          </p>
+          <TerminalLabel>Projects in Development</TerminalLabel>
+          <div className="grid gap-4">
+            <ProjectCard
+              title="DevCreds"
+              description="Developer reputation dapp for the Arbitrum ecosystem"
+              linkUrl="https://dev-creds.vercel.app/"
+            />
+            <ProjectCard
+              title="Governance Dashboard"
+              description="Dashboard for Arbitrum governance participation and tracking"
+            />
+          </div>
+        </>
+      ),
+      links: [{ url: "https://arbitrum.buidlguidl.com/", label: "Website" }],
+    },
+    {
+      id: "jobboard",
+      title: "Job Board",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            Curated job board connecting developers with opportunities across the Ethereum ecosystem.
+          </p>
+          <TaskList tasks={["Launched the Ethereum Job Board in collaboration with Geode Labs"]} />
+          <TerminalLabel>2025 Stats</TerminalLabel>
+          <InlineStats stats={[{ value: "8.1k", label: "visitors" }]} />
+        </>
+      ),
+      links: [{ url: "https://www.ethereumjobboard.com/", label: "Website" }],
+    },
+    {
+      id: "ethereumorg",
+      title: "Ethereum.org",
+      content: (
+        <TaskList
+          tasks={[
+            <>
+              Built the <DarkLink href="https://ethereum.org/collectibles/">Collectibles</DarkLink> site for
+              contributors
+            </>,
+            <>
+              Speedrun Ethereum and Scaffold-ETH are featured as main themes on{" "}
+              <DarkLink href="https://ethereum.org/developers/">ethereum.org/developers/</DarkLink>
+            </>,
+          ]}
+        />
+      ),
+    },
+  ],
+};
+
+const MISC: RecapSectionData = {
+  id: "misc",
+  track: "Dapp Building Track",
+  title: "Miscellaneous Projects",
+  navTitle: "Misc",
+  intro: (
+    <>
+      Side projects and experiments. Beyond our main initiatives, we maintained useful tools, explored emerging
+      platforms like Farcaster MiniApps, and started ideating programs for 2026.
+    </>
+  ),
+  stats: [
+    { value: "~20k", label: "", growth: "Abi Ninja users" },
+    { value: "3", label: "", growth: "Farcaster Miniapps" },
+  ],
+  tabs: [
+    {
+      id: "abi-ninja",
+      title: "Abi Ninja",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            Our tool for interacting with any smart contract on any EVM chain. In 2025, we focused on maintenance and
+            incremental improvements to keep it running smoothly.
+          </p>
+          <TerminalLabel>Highlights</TerminalLabel>
+          <TaskList tasks={["Maintenance and small features"]} />
+        </>
+      ),
+      links: [{ url: "https://abi.ninja/", label: "Website" }],
+    },
+    {
+      id: "farcaster",
+      title: "Farcaster Miniapps",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            Exploring the miniapp ecosystem after our Farcaster day at Devconnect by launching experimental games and
+            interactive experiences.
+          </p>
+          <TerminalLabel>Launched Miniapps</TerminalLabel>
+          <TaskList
+            tasks={[
+              <>
+                <span className="text-white">Advent Calendar</span> — Holiday-themed miniapp game (
+                <DarkLink href="https://farcaster.xyz/miniapps/mhdgdBnT4lR0/adventsfun-calendar">Open Miniapp</DarkLink>
+                )
+              </>,
+              <>
+                <span className="text-white">Snowman / Not Snowman</span> — Spinoff farcaster drawing game (
+                <DarkLink href="https://farcaster.xyz/miniapps/q-h3sLIksfzg/snowman--not-snowman">
+                  Open Miniapp
+                </DarkLink>
+                )
+              </>,
+              <>
+                <span className="text-white">Bubble Tap</span> — Spinoff Interactive tap game (
+                <DarkLink href="https://farcaster.xyz/miniapps/LTGZffIuAcG7/bubble-tap-game">Open Miniapp</DarkLink>)
+              </>,
+            ]}
+          />
+        </>
+      ),
+    },
+    {
+      id: "ideation",
+      title: "2026 Ideation",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            Exploring new directions and prototyping programs to launch in the coming year.
+          </p>
+          <TerminalLabel>Prototypes & Concepts</TerminalLabel>
+          <div className="grid gap-4">
+            <ProjectCard
+              title="6-Month Acceleration Program"
+              description="Ideation and prototyping of a structured builder program"
+              linkUrl="https://hack-combinator.vercel.app/"
+              linkLabel="View prototype"
+            />
+            <ProjectCard
+              title="Enterprise Education"
+              description="Mockup for enterprise-focused Ethereum education"
+              linkUrl="https://eadc.ethereum.org/"
+              linkLabel="View prototype"
+            />
+          </div>
+        </>
+      ),
+    },
+  ],
+};
+
+export const RECAP_SECTIONS: RecapSectionData[] = [SPEEDRUN, SCAFFOLD_ETH, EDUCATIONAL, ECOSYSTEM, MISC];

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 /**
  * Site footer
@@ -20,6 +21,12 @@ export const Footer = () => {
               <a href="https://speedrunethereum.com/builds" target="_blank" rel="noreferrer" className="m-0">
                 Builds
               </a>
+              <Link href="/batches" className="m-0">
+                Batches
+              </Link>
+              <Link href="/2025" className="m-0">
+                2025 Recap
+              </Link>
               <a href="https://github.com/scaffold-eth/scaffold-eth-2" target="_blank" rel="noreferrer" className="m-0">
                 Scaffold-ETH 2
               </a>

--- a/packages/nextjs/pages/2025.tsx
+++ b/packages/nextjs/pages/2025.tsx
@@ -1,0 +1,96 @@
+import type { NextPage } from "next";
+import { RecapSection } from "~~/components/2025/RecapSection";
+import { SectionNav } from "~~/components/2025/SectionNav";
+import { TerminalWindow } from "~~/components/2025/TerminalWindow";
+import { RECAP_SECTIONS } from "~~/components/2025/sections";
+import { Footer } from "~~/components/Footer";
+import { Header } from "~~/components/Header";
+import { MetaHeader } from "~~/components/MetaHeader";
+
+const HERO_STATS = [
+  { label: "sre_visitors", value: "92,400" },
+  { label: "sre_signups", value: "5,700" },
+  { label: "se2_repos", value: "2,243" },
+];
+
+const TRACK_CHIPS = [
+  { href: "#speedrun", label: "education" },
+  { href: "#scaffold-eth", label: "tooling" },
+  { href: "#ecosystem", label: "collabs" },
+];
+
+const Recap2025: NextPage = () => {
+  return (
+    <>
+      <MetaHeader
+        title="2025 Recap - BuidlGuidl"
+        description="A look back at what BuidlGuidl shipped in 2025: Speedrun Ethereum, Scaffold-ETH 2, educational initiatives, and ecosystem collabs."
+        image={`api/og?title=${encodeURIComponent("2025 Recap")}`}
+        path="/2025"
+      />
+
+      {/* Title band, hero-style fade behind the header */}
+      <div className="hero-fade">
+        <Header transparent />
+        <header className="w-full max-w-[860px] mx-auto px-5 sm:px-6 pt-4 pb-10 sm:pt-8 sm:pb-14">
+          <h1 className="text-3xl sm:text-[2.5rem] sm:leading-[1.15] mb-4">2025 Recap</h1>
+          <p className="text-base sm:text-lg text-base-content/70 leading-relaxed m-0">
+            BuidlGuidl builds products, tools, and educational resources to onboard developers to Ethereum and help them
+            grow in the ecosystem. In 2025, we shipped big upgrades to Speedrun Ethereum and Scaffold-ETH 2, helped run
+            several educational initiatives, and partnered to build new tools with ENS, Arbitrum, and others.
+          </p>
+
+          {/* Stats line - terminal style */}
+          <div className="flex flex-wrap gap-x-5 gap-y-1 mt-5 font-mono text-xs sm:text-sm text-base-content/60">
+            {HERO_STATS.map(stat => (
+              <span key={stat.label}>
+                <span className="text-primary">$</span> {stat.label}:{" "}
+                <span className="text-base-content font-medium">{stat.value}</span>
+              </span>
+            ))}
+          </div>
+
+          {/* Track chips */}
+          <div className="flex flex-wrap gap-2 mt-5">
+            {TRACK_CHIPS.map(track => (
+              <a
+                key={track.href}
+                href={track.href}
+                className="px-3 py-1 font-mono text-xs text-base-content/50 border border-base-content/15 rounded-md hover:border-primary hover:text-base-content transition-colors"
+              >
+                /{track.label}
+              </a>
+            ))}
+          </div>
+        </header>
+      </div>
+
+      {/* Body: section nav sidebar + boxed sections */}
+      <div className="bg-skin">
+        <div className="w-full max-w-[1440px] mx-auto px-4 sm:px-6 py-8 sm:py-12 flex flex-col xl:flex-row xl:justify-center items-stretch xl:items-start gap-8">
+          <SectionNav />
+          <main className="w-full max-w-[860px] mx-auto xl:mx-0 flex flex-col gap-8">
+            {RECAP_SECTIONS.map(section => (
+              <RecapSection
+                key={section.id}
+                id={section.id}
+                track={section.track}
+                title={section.title}
+                intro={section.intro}
+                stats={section.stats}
+              >
+                <TerminalWindow tabs={section.tabs} />
+              </RecapSection>
+            ))}
+          </main>
+          {/* Spacer to keep the sections centered next to the nav */}
+          <div className="hidden xl:block w-52 shrink-0" />
+        </div>
+      </div>
+
+      <Footer />
+    </>
+  );
+};
+
+export default Recap2025;

--- a/packages/nextjs/public/llms.txt
+++ b/packages/nextjs/public/llms.txt
@@ -18,6 +18,7 @@
 - [Projects](https://buidlguidl.com/projects): open source tools and apps we build and maintain
 - [Blog](https://buidlguidl.com/blog): writing on tooling, education, and research
 - [Batches](https://buidlguidl.com/batches): a program to level up as an open source dApp developer
+- [2025 Recap](https://buidlguidl.com/2025): what BuidlGuidl shipped in 2025
 
 ## Blog posts
 - [Evaluating agent skills: testing whether they are actually useful](https://buidlguidl.com/blog/evaluating-agent-skills)


### PR DESCRIPTION
Adds a `/2025` recap page, ported from sandgarden.buidlguidl.com and restyled to match the blog (hero band, sticky section nav, white cards, dark terminal-style tabs).

- Content rephrased for BuidlGuidl voice
- 5 sections: Speedrun Ethereum, Scaffold-ETH 2, Educational Initiatives, Ecosystem Collabs, Misc
- Footer: add **Batches** and **2025 Recap** links
- `llms.txt`: add `/2025` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192ebD4oZNtSFWxK8RJZ8u2