### PR TITLE
Added section for BG Client and BG RPC work to 2025 recap page

### DIFF
--- a/packages/nextjs/components/2025/sections.tsx
+++ b/packages/nextjs/components/2025/sections.tsx
@@ -507,6 +507,13 @@ const NODE_INFRA: RecapSectionData = {
               "Improved response speeds with caching and smarter request routing",
             ]}
           />
+          <TerminalLabel>2025 Stats</TerminalLabel>
+          <InlineStats
+            stats={[
+              { value: "5 million+", label: "requests served" },
+              { value: "3", label: "continents hosting supporting nodes" },
+            ]}
+          />
         </>
       ),
       links: [{ url: "https://rpc.buidlguidl.com/", label: "Website" }],

--- a/packages/nextjs/components/2025/sections.tsx
+++ b/packages/nextjs/components/2025/sections.tsx
@@ -499,7 +499,7 @@ const NODE_INFRA: RecapSectionData = {
 
           <TaskList
             tasks={[
-              "Launched the RPC and immediately started handling mainnet requests at no cost to users",
+              "Launched the BG RPC and immediately started handling mainnet requests at no cost to users",
               <>
                 Started rewarding BG Client node runners who support the BG RPC with the{" "}
                 <DarkLink href="https://bread.buidlguidl.com/">Bread</DarkLink> ERC-20 token

--- a/packages/nextjs/components/2025/sections.tsx
+++ b/packages/nextjs/components/2025/sections.tsx
@@ -467,7 +467,7 @@ const NODE_INFRA: RecapSectionData = {
       content: (
         <>
           <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
-            One line command to run an Ethereum full node, with a terminal dashboard for monitoring.
+            One line command to run an Ethereum full node with a terminal dashboard for monitoring.
           </p>
 
           <TaskList
@@ -494,7 +494,7 @@ const NODE_INFRA: RecapSectionData = {
       content: (
         <>
           <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
-            A free mainnet RPC endpoint, served entirely by the community-run nodes in the BG Client network.
+            A free mainnet RPC endpoint, served entirely by community-run BG Client nodes.
           </p>
 
           <TaskList

--- a/packages/nextjs/components/2025/sections.tsx
+++ b/packages/nextjs/components/2025/sections.tsx
@@ -449,6 +449,91 @@ const ECOSYSTEM: RecapSectionData = {
   ],
 };
 
+const NODE_INFRA: RecapSectionData = {
+  id: "node-infra",
+  track: "Infrastructure Track",
+  title: "Ecosystem Support",
+  navTitle: "Ecosystem Support",
+  intro: (
+    <>
+      We improved the BuidlGuidl Client UX and launched a free distributed mainnet RPC that{"'"}s powered by BG Clients.
+    </>
+  ),
+  tabs: [
+    {
+      id: "bg-client",
+      title: "BG Client",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            One line command to run an Ethereum full node, with a terminal dashboard for monitoring.
+          </p>
+
+          <TaskList
+            tasks={[
+              "Started powering the BG RPC with a network of BG Clients",
+              <>
+                Added Telegram alerts and a{" "}
+                <DarkLink href="https://apps.apple.com/us/app/bg-client/id6756518184">Mac and iOS app</DarkLink> for
+                monitoring node status
+              </>,
+              "Kept the execution (Geth & Reth) and consensus (Prysm & Lighthouse) clients current all year.",
+            ]}
+          />
+        </>
+      ),
+      links: [
+        { url: "https://client.buidlguidl.com/", label: "Website" },
+        { url: "https://github.com/BuidlGuidl/buidlguidl-client", label: "Github" },
+      ],
+    },
+    {
+      id: "bg-rpc",
+      title: "BG RPC",
+      content: (
+        <>
+          <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
+            A community-powered RPC endpoint served by BG Client nodes. It started from an empty repo in January 2025
+            and grew into the pool service that routes, verifies, and pays for every request.
+          </p>
+
+          <TerminalLabel>Request Routing</TerminalLabel>
+          <TaskList
+            tasks={[
+              "Built the pool from scratch: socket.io check-ins, a live map of connected nodes, and per-request timeouts",
+              "Raced each request across three nodes and returned the fastest response, later tuned down to a single node with random spot check sets",
+              "Added a caching layer for eth_call, eth_getBalance, eth_getStorageAt, eth_getBlockByNumber and friends, keyed by params and block number",
+              "Added dynamic timeouts for slower methods and a retry when the first node times out",
+            ]}
+          />
+
+          <TerminalLabel>Trust & Verification</TerminalLabel>
+          <TaskList
+            tasks={[
+              "Compared responses key by key across nodes and raised Telegram alerts on mismatches",
+              "Blocked block number spoofing by checking each node's reported head against the mode of the pool",
+              "Scored nodes fast or slow by their timeout percentage over the trailing week, and filtered out stale or partial check-ins",
+            ]}
+          />
+
+          <TerminalLabel>Rewards & Public Data</TerminalLabel>
+          <TaskList
+            tasks={[
+              "Replaced owner points with Bread minted on Base: staged to a database, batched, ENS resolved, with mint capacity preflight and nonce error recovery",
+              <>
+                Shipped the endpoints behind the client and{" "}
+                <DarkLink href="https://rpc.buidlguidl.com/">rpc.buidlguidl.com</DarkLink>: /poolNodes, /nodeContinents,
+                /rpcsitestats, /yournodes with per-node system stats, and /watchdog
+              </>,
+            ]}
+          />
+        </>
+      ),
+      links: [{ url: "https://rpc.buidlguidl.com/", label: "Website" }],
+    },
+  ],
+};
+
 const MISC: RecapSectionData = {
   id: "misc",
   track: "Dapp Building Track",
@@ -542,4 +627,4 @@ const MISC: RecapSectionData = {
   ],
 };
 
-export const RECAP_SECTIONS: RecapSectionData[] = [SPEEDRUN, SCAFFOLD_ETH, EDUCATIONAL, ECOSYSTEM, MISC];
+export const RECAP_SECTIONS: RecapSectionData[] = [SPEEDRUN, SCAFFOLD_ETH, EDUCATIONAL, ECOSYSTEM, NODE_INFRA, MISC];

--- a/packages/nextjs/components/2025/sections.tsx
+++ b/packages/nextjs/components/2025/sections.tsx
@@ -456,7 +456,8 @@ const NODE_INFRA: RecapSectionData = {
   navTitle: "Ecosystem Support",
   intro: (
     <>
-      We improved the BuidlGuidl Client UX and launched a free distributed mainnet RPC that{"'"}s powered by BG Clients.
+      We improved the BuidlGuidl Client UX and launched a free distributed mainnet RPC that{"'"}s powered by BG Client
+      nodes.
     </>
   ),
   tabs: [
@@ -477,7 +478,7 @@ const NODE_INFRA: RecapSectionData = {
                 <DarkLink href="https://apps.apple.com/us/app/bg-client/id6756518184">Mac and iOS app</DarkLink> for
                 monitoring node status
               </>,
-              "Kept the execution (Geth & Reth) and consensus (Prysm & Lighthouse) clients current all year.",
+              "Kept the execution (Geth & Reth) and consensus (Prysm & Lighthouse) clients current all year",
             ]}
           />
         </>
@@ -493,38 +494,17 @@ const NODE_INFRA: RecapSectionData = {
       content: (
         <>
           <p className="text-white/70 text-sm leading-relaxed mt-0 mb-6">
-            A community-powered RPC endpoint served by BG Client nodes. It started from an empty repo in January 2025
-            and grew into the pool service that routes, verifies, and pays for every request.
+            A free mainnet RPC endpoint, served entirely by the community-run nodes in the BG Client network.
           </p>
 
-          <TerminalLabel>Request Routing</TerminalLabel>
           <TaskList
             tasks={[
-              "Built the pool from scratch: socket.io check-ins, a live map of connected nodes, and per-request timeouts",
-              "Raced each request across three nodes and returned the fastest response, later tuned down to a single node with random spot check sets",
-              "Added a caching layer for eth_call, eth_getBalance, eth_getStorageAt, eth_getBlockByNumber and friends, keyed by params and block number",
-              "Added dynamic timeouts for slower methods and a retry when the first node times out",
-            ]}
-          />
-
-          <TerminalLabel>Trust & Verification</TerminalLabel>
-          <TaskList
-            tasks={[
-              "Compared responses key by key across nodes and raised Telegram alerts on mismatches",
-              "Blocked block number spoofing by checking each node's reported head against the mode of the pool",
-              "Scored nodes fast or slow by their timeout percentage over the trailing week, and filtered out stale or partial check-ins",
-            ]}
-          />
-
-          <TerminalLabel>Rewards & Public Data</TerminalLabel>
-          <TaskList
-            tasks={[
-              "Replaced owner points with Bread minted on Base: staged to a database, batched, ENS resolved, with mint capacity preflight and nonce error recovery",
+              "Launched the RPC and immediately started handling mainnet requests at no cost to users",
               <>
-                Shipped the endpoints behind the client and{" "}
-                <DarkLink href="https://rpc.buidlguidl.com/">rpc.buidlguidl.com</DarkLink>: /poolNodes, /nodeContinents,
-                /rpcsitestats, /yournodes with per-node system stats, and /watchdog
+                Started rewarding BG Client node runners who support the BG RPC with the{" "}
+                <DarkLink href="https://bread.buidlguidl.com/">Bread</DarkLink> ERC-20 token
               </>,
+              "Improved response speeds with caching and smarter request routing",
             ]}
           />
         </>

--- a/packages/nextjs/pages/2025.tsx
+++ b/packages/nextjs/pages/2025.tsx
@@ -17,6 +17,7 @@ const TRACK_CHIPS = [
   { href: "#speedrun", label: "education" },
   { href: "#scaffold-eth", label: "tooling" },
   { href: "#ecosystem", label: "collabs" },
+  { href: "#node-infra", label: "infra" },
 ];
 
 const Recap2025: NextPage = () => {


### PR DESCRIPTION
@carletex, I added an "Ecosystem Support" section that goes over the big picture changes for the BG Client and BG RPC. Note that the BG RPC's biggest change was that it was launched in 2025. A lot of work was behind the scenes and mostly bug fixes, security stuff, and performance improvements but I tried to pick changes that the public would care about.

There's one big missing piece: stats.
- We don't track how many total BG Client users there are. We do know that there's ~15 BG Client users supporting the RPC spread across 3 continents. Those stats aren't too impressive. 
- For the RPC side we don't keep long-term records in a database or anything so I likewise don't have stats on how many actual requests we've served. I have a good idea requests served on a typical day so we could say something like "+5 million requests served" for 2025...